### PR TITLE
Add coverage to tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 .cache
 dist
 lib
+coverage

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "start": "tsdx watch",
     "build": "rollup -c",
-    "test": "tsdx test --passWithNoTests",
+    "test": "tsdx test --passWithNoTests --coverage",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx --quiet",
     "lint-fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
     "prepare": "tsdx build",


### PR DESCRIPTION
Adds the test coverage to the `npm run test`. It produces quick lookup in the terminal:

![image](https://user-images.githubusercontent.com/11715931/109802733-7776bc80-7c20-11eb-99c0-11c425037453.png)

...and `coverage` directory. You can explore the coverage results in the html file: `coverage/lcov-report/index.html`:

![image](https://user-images.githubusercontent.com/11715931/109802913-abea7880-7c20-11eb-8a76-4575bc86b735.png)

![image](https://user-images.githubusercontent.com/11715931/109802965-c0c70c00-7c20-11eb-91b9-13fc5bb333f5.png)
